### PR TITLE
Switch from fabsto abs to avoid complier errors

### DIFF
--- a/test/SigmoidalRateConstantTest.cpp
+++ b/test/SigmoidalRateConstantTest.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <ModFossa/ModelDefinition/SigmoidalRateConstant.h>
 #include <ModFossa/Common/StateOfTheWorld.h>
+#include <math.h>
 
 using namespace ModFossa;
 using std::string;
@@ -88,7 +89,7 @@ TEST_F(SigmoidalRateConstantTest, getRate) {
     double actual = rate_constant->getRate(state_of_the_world);
     double expected = 1.0999363635;
 
-    double error = abs(actual - expected);
+    double error = fabs(actual - expected);
     ASSERT_LT(error, error_allowed);
 
     delete rate_constant;


### PR DESCRIPTION
Hi,
I encountered some errors when I tried to compile modfossa:

```
~/modfossa/test/SigmoidalRateConstantTest.cpp: In member function ‘virtual void SigmoidalRateConstantTest_getRate_Test::TestBody()’:
~/modfossa/test/SigmoidalRateConstantTest.cpp:91:41: error: call of overloaded ‘abs(double)’ is ambiguous
     double error = abs(actual - expected);
```

The commit in this PR solved the issue for me. 

best
Tobias
